### PR TITLE
Add `fetch` to ResponseDisplay

### DIFF
--- a/app/controllers/api/v1/responses_controller.rb
+++ b/app/controllers/api/v1/responses_controller.rb
@@ -1,7 +1,7 @@
 class Api::V1::ResponsesController < ApplicationController
   before_action :set_response, only: [:show]
-  # GET /responses
-  # GET /responses.json
+
+  # GET /responses/:id
   def show
     if @response
       # render json: @response
@@ -31,7 +31,7 @@ class Api::V1::ResponsesController < ApplicationController
       catalog[:ANSWERS] = {}
       response.answers.each do |answer|
         response_option = answer.response_option
-        catalog[:ANSWERS][answer.id] = response_option
+        catalog[:ANSWERS][answer.question_id] = response_option
       end
       return catalog
     end


### PR DESCRIPTION
Resolves #9 

Addresses #9; also discovered a bug in responses controller,
which went undeteced since the first two answer objects
had the same id as the first two question objects
(1 and 2); we wanted the response catalog to return an answer
hash with keys 'the question that this one answers'
and values 'the response option selected'.

There is a potential extra/early fetch occuring whereby poll
data is fetched before response data is set to state,
so that response_data.RESPONSE.poll_id is undefined, forcing
another fetch. Creating issue for this.