### PR TITLE
Resolve #10

### DIFF
--- a/app/javascript/components/ResponseDisplay/ResponseDisplay.jsx
+++ b/app/javascript/components/ResponseDisplay/ResponseDisplay.jsx
@@ -27,7 +27,8 @@ export default function ResponseDisplay(props) {
               setMountStatus(true);
               // response_data loaded
               // fetch the associated poll data
-              const poll_id = response_data.RESPONSE.poll_id;
+              // const poll_id = response_data.RESPONSE.poll_id;
+              const poll_id = data.RESPONSE.poll_id;
               const poll_url = `/api/v1/polls/${poll_id}`
               fetch(poll_url)
                 .then((data) => {


### PR DESCRIPTION
`setState` is async, so rather than setting the response data
and then calling up the (recently set) state for the response id,
we instead call it directly from the fetched data object.